### PR TITLE
Add tts and stt

### DIFF
--- a/PersonaChat.xcodeproj/project.pbxproj
+++ b/PersonaChat.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 				INFOPLIST_FILE = PersonaChat/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoryFriends;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.books";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Enable this if you want to speak to the app";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Enable this if you want the app to recognize your speech";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -186,7 +188,7 @@
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -213,6 +215,8 @@
 				INFOPLIST_FILE = PersonaChat/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = StoryFriends;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.books";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Enable this if you want to speak to the app";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Enable this if you want the app to recognize your speech";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -233,7 +237,7 @@
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;

--- a/PersonaChat/Models/TTS.swift
+++ b/PersonaChat/Models/TTS.swift
@@ -1,0 +1,40 @@
+//
+//  TTS.swift
+//  PersonaChat
+//
+//  Created by Mohammed on 9/18/25.
+//
+
+import AVFoundation
+
+extension String {
+    @MainActor
+    func speak(rate: Float? = nil, language: String = "en-US") {
+        let utterance = AVSpeechUtterance(string: self.withoutEmojis)
+
+        // Find the highest-quality voice
+        utterance.voice = .highestQualityVoice(for: language)
+
+        if let rate = rate {
+            utterance.rate = rate
+        }
+        let synthesizer = AVSpeechSynthesizer()
+        synthesizer.speak(utterance)
+    }
+
+    fileprivate var withoutEmojis: Self {
+        unicodeScalars
+            .filter { !$0.properties.isEmojiPresentation && !$0.properties.isEmoji }
+            .map(String.init)
+            .joined()
+    }
+}
+
+extension AVSpeechSynthesisVoice {
+    static func highestQualityVoice(for language: String) -> AVSpeechSynthesisVoice? {
+        Self.speechVoices()
+            .filter { $0.language == language }
+            .sorted { $0.quality.rawValue > $1.quality.rawValue }
+            .first ?? AVSpeechSynthesisVoice(language: language)
+    }
+}

--- a/PersonaChat/ViewModels/Transcribe.swift
+++ b/PersonaChat/ViewModels/Transcribe.swift
@@ -1,0 +1,77 @@
+//
+//  Transcribe.swift
+//  PersonaChat
+//
+//  Created by Mohammed on 9/18/25.
+//
+
+import Speech
+import AVFoundation
+
+final class SpeechRecognizer {
+    private let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    func start(onUpdate: @escaping (String) -> Void, onFinish: (() -> Void)? = nil) {
+        Task {
+            guard await Self.requestAuth(), let recognizer, recognizer.isAvailable else {
+                onFinish?()
+                return
+            }
+
+            do {
+                try configureSession()
+
+                let r = SFSpeechAudioBufferRecognitionRequest()
+                r.shouldReportPartialResults = true
+                request = r
+
+                let input = audioEngine.inputNode
+                let format = input.outputFormat(forBus: 0)
+                input.removeTap(onBus: 0)
+                input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buf, _ in
+                    self?.request?.append(buf)
+                }
+
+                audioEngine.prepare()
+                try audioEngine.start()
+
+                task = recognizer.recognitionTask(with: r) { result, error in
+                    if let text = result?.bestTranscription.formattedString {
+                        onUpdate(text)   // <-- callback with transcript
+                    }
+                    if result?.isFinal == true || error != nil {
+                        self.stop()
+                        onFinish?()
+                    }
+                }
+            } catch {
+                onFinish?()
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+        request?.endAudio()
+        request = nil
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+        try? AVAudioSession.sharedInstance().setActive(false)
+    }
+
+    private static func requestAuth() async -> Bool {
+        await withCheckedContinuation { cont in
+            SFSpeechRecognizer.requestAuthorization { cont.resume(returning: $0 == .authorized) }
+        }
+    }
+
+    private func configureSession() throws {
+        let s = AVAudioSession.sharedInstance()
+        try s.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try s.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/PersonaChat/Views/ChatView.swift
+++ b/PersonaChat/Views/ChatView.swift
@@ -50,7 +50,7 @@ struct ChatView: View {
     @State
     private var hapticTrigger: Int = 0
 
-    /// Text to speach mode
+    /// Text to speech mode
     @State
     private var tts = true
 

--- a/PersonaChat/Views/ChatView.swift
+++ b/PersonaChat/Views/ChatView.swift
@@ -197,18 +197,6 @@ struct ChatView: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-#if os(macOS)
-        ToolbarItem {
-            Picker("Persona", selection: $selectedPersonaID) {
-                ForEach(PERSONAS, id: \.id) { persona in
-                    Text("\(persona.emoji)  \(persona.name)")
-                        .font(persona.font)
-                        .tag(persona.id)
-                }
-            }
-            .pickerStyle(.menu)
-        }
-#endif
         ToolbarItem(placement: .topBarLeading) {
             Button(
                 "Speaker on",

--- a/PersonaChat/Views/MessageRow.swift
+++ b/PersonaChat/Views/MessageRow.swift
@@ -26,7 +26,7 @@ struct MessageRow: View {
             }
             .padding()
         } else {
-            if #available(iOS 26.0, macOS 26.0, *) {
+            if #available(iOS 26.0, *) {
                 MaybeMarkdown(message.text)
                     .padding(.horizontal)
                     .lineHeight(.loose)


### PR DESCRIPTION
This pull request adds speech synthesis (text-to-speech) and speech recognition (voice-to-text) features to the app, and updates platform support and permissions accordingly. The main changes include new models for TTS and transcription, UI updates to allow users to toggle TTS and record speech, and project configuration changes to support these capabilities.

**Speech Features**

* Added a new `TTS.swift` model with a `String.speak()` extension for text-to-speech using `AVSpeechSynthesizer`, including emoji removal and selection of the highest quality voice.
* Added a new `Transcribe.swift` model with a `SpeechRecognizer` class to handle speech-to-text transcription using Apple's `Speech` framework.

**UI Integration**

* Updated `ChatView.swift` to include state for TTS and transcription, added toolbar button to toggle TTS, and a record/stop button to start/stop speech recognition. [[1]](diffhunk://#diff-89dce2ef71a40254bc3dd00963f8715245524ecbde8c20a0f11d73686a4f77fbR53-R61) [[2]](diffhunk://#diff-89dce2ef71a40254bc3dd00963f8715245524ecbde8c20a0f11d73686a4f77fbR139-R153) [[3]](diffhunk://#diff-89dce2ef71a40254bc3dd00963f8715245524ecbde8c20a0f11d73686a4f77fbL176-L187)
* Calls `.speak()` on bot responses to enable TTS playback when appropriate.

**Project Configuration and Permissions**

* Updated `project.pbxproj` to add microphone and speech recognition usage descriptions to the Info.plist, and removed macOS from supported platforms. [[1]](diffhunk://#diff-d9a0b62e6898ebb972108db220f6b0877deab2e640a4e398b5b0cca1fdef1608R169-R170) [[2]](diffhunk://#diff-d9a0b62e6898ebb972108db220f6b0877deab2e640a4e398b5b0cca1fdef1608L189-R191) [[3]](diffhunk://#diff-d9a0b62e6898ebb972108db220f6b0877deab2e640a4e398b5b0cca1fdef1608R218-R219) [[4]](diffhunk://#diff-d9a0b62e6898ebb972108db220f6b0877deab2e640a4e398b5b0cca1fdef1608L236-R240)

**Minor Compatibility Fix**

* Fixed platform availability check in `MessageRow.swift` to only require iOS 26.0+.